### PR TITLE
fix Wikimaps URL format for 1x

### DIFF
--- a/sidebar/components/mercator/mercator.tpl.js
+++ b/sidebar/components/mercator/mercator.tpl.js
@@ -2,7 +2,7 @@ templates.mercator = (vars) => {
 	let tag = document.createElement('img');
 	let zoom = parseInt((vars.pre + 4) * 4);
 	let maps = {
-    '1x': `https://maps.wikimedia.org/img/osm-intl,${ zoom },${ vars.lat },${ vars.lon },${ vars.width }x${ vars.height }@1x.png`,
+    '1x': `https://maps.wikimedia.org/img/osm-intl,${ zoom },${ vars.lat },${ vars.lon },${ vars.width }x${ vars.height }.png`,
     '2x': `https://maps.wikimedia.org/img/osm-intl,${ zoom },${ vars.lat },${ vars.lon },${ vars.width }x${ vars.height }@2x.png`
 	};
 


### PR DESCRIPTION
The `@1x` at the end does not work resulting in no displayed map. A `@...x` must only be provided for it larger than 1 and otherwise 1 is assumed.