### PR TITLE
make getAutodesc more resilient to outages of its service

### DIFF
--- a/sidebar/get-autodesc.js
+++ b/sidebar/get-autodesc.js
@@ -1,10 +1,12 @@
 async function getAutodesc(id) {
-	const lang = navigator.language.substr(0,2);
-	let response = await fetch('https://tools.wmflabs.org/autodesc/?q=' + id + '&lang=' + lang + '&mode=short&links=text&redlinks=&format=json');
-	let json = JSON.parse(await response.text());
-	if (!json.result.match(/<i>/)) {
-		return json.result;
-	} else {
+	try {
+		const lang = navigator.language.substr(0,2);
+		let response = await fetch('https://autodesc.toolforge.org/?q=' + id + '&lang=' + lang + '&mode=short&links=text&redlinks=&format=json');
+		let json = await response.json();
+		if (!json.result.match(/<i>/)) {
+			return json.result;
+		}
+	} finally {
 		return '???';
 	}
 }


### PR DESCRIPTION
I just received non-200 responses from Autodesc breaking the description resolution and with that the full entity view, that leads to this pr to catch any exception within the autodesc function.