### PR TITLE
make use of navigator.languages

### DIFF
--- a/content__collect-strings.js
+++ b/content__collect-strings.js
@@ -23,7 +23,7 @@ function guessLanguage(string) {
 		return 'de';
 	}
 	// if all else fails, let's assume it is something the user can read
-  return navigator.language.substr(0,2);
+  return navigator.language.split("-")[0];
 }
 
 document.addEventListener('selectionchange', (e) => {

--- a/sidebar/components/placeholder/placeholder.tpl.js
+++ b/sidebar/components/placeholder/placeholder.tpl.js
@@ -3,10 +3,10 @@ let cache = {}
 templates.placeholder = (vars) => {
 
 	// don't create a placeholder if the label is already in cache
-	if (vars.entity && cache.labels[vars.entity] && !vars.type) {
+	if (vars.entity && 'labels' in cache && cache.labels[vars.entity] && !vars.type) {
 		let link = document.createElement('a')
 		link.innerText = cache.labels[vars.entity];
-		if (cache.descriptions[vars.entity]) {
+		if ('descriptions' in cache && cache.descriptions[vars.entity]) {
 			link.setAttribute('title', cache.descriptions[vars.entity]);
 		}
 		link.setAttribute('href', getLink(vars.entity));

--- a/sidebar/connector.html
+++ b/sidebar/connector.html
@@ -14,6 +14,7 @@
   <script src="wd-get-token.js"></script>
   
   <script src="components/templates.tpl.js"></script>
+  <script src="components/placeholder/placeholder.tpl.js"></script>
   <script src="components/remark/remark.tpl.js"></script>
   <script src="components/join/join.tpl.js"></script>
   <script src="components/direction/direction.tpl.js"></script>

--- a/sidebar/get-autodesc.js
+++ b/sidebar/get-autodesc.js
@@ -1,6 +1,6 @@
 async function getAutodesc(id) {
 	try {
-		const lang = navigator.language.substr(0,2);
+		const lang = navigator.language.split("-")[0];
 		let response = await fetch('https://autodesc.toolforge.org/?q=' + id + '&lang=' + lang + '&mode=short&links=text&redlinks=&format=json');
 		let json = await response.json();
 		if (!json.result.match(/<i>/)) {

--- a/sidebar/get-autodesc.js
+++ b/sidebar/get-autodesc.js
@@ -6,7 +6,8 @@ async function getAutodesc(id) {
 		if (!json.result.match(/<i>/)) {
 			return json.result;
 		}
-	} finally {
-		return '???';
+	} catch (ex) {
+		console.log(ex);
 	}
+	return '???';
 }

--- a/sidebar/get-value-by-lang.js
+++ b/sidebar/get-value-by-lang.js
@@ -1,16 +1,13 @@
 function getValueByLang(e, key, fallback) {
-	const lang = navigator.language.substr(0,2);
+	const langs = navigator.languages.map(lang => lang.split("-")[0]).filter((e,i,a) => a.indexOf(e) == i);
 	
 	if (!fallback) {
 		let fallback = '';
 	}
 	if (e.hasOwnProperty(key)) {
-		if (e[key].hasOwnProperty(lang)) {
-			if (e[key][lang].hasOwnProperty('value')) {
-				return e[key][lang].value;
-			} else {
-				return fallback;
-			}
+		let matches = langs.map(lang => e[key].hasOwnProperty(lang) && e[key][lang].hasOwnProperty('value') ? e[key][lang].value : null).filter(match => match !== null);
+		if (matches.length >= 1) {
+			return matches[0];
 		} else {
 			return fallback;
 		}
@@ -20,7 +17,7 @@ function getValueByLang(e, key, fallback) {
 }
 
 function getAliasesByLang(e) {
-	const lang = navigator.language.substr(0,2);
+	const lang = navigator.language.split("-")[0];
 	if (e.hasOwnProperty('aliases')) {
 		if (e['aliases'].hasOwnProperty(lang)) {
 			return e['aliases'][lang].map((o) => { return o.value });


### PR DESCRIPTION
Firefox has with `navigator.languages` a list of a user's preferred languages.  “[T]hey are ordered by preference with the most preferred language first” (https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages) getValueByLang could make use of all of it and not only the single most preferred one before falling back to another value. 

Also: `navigator.language` can in theory have three digit language codes. (see https://tools.ietf.org/html/bcp47#section-2.1) So I suggest splitting by potential dashes instead.

(And I got some exceptions thrown in browser console, so I adjusted placeholder.tpl.js get-autodesc.js a bit.)

p.s. I found another bug with the connector not having the new placeholder template script breaking the former. Sorry for utterly overloading this pr.